### PR TITLE
Include Phoenix version patch for changelong link

### DIFF
--- a/installer/lib/phx_new/generator.ex
+++ b/installer/lib/phx_new/generator.ex
@@ -115,7 +115,7 @@ defmodule Phx.New.Generator do
       web_app_name: project.web_app,
       endpoint_module: inspect(Module.concat(project.web_namespace, Endpoint)),
       web_namespace: inspect(project.web_namespace),
-      phoenix_github_version_tag: "v#{version.major}.#{version.minor}",
+      phoenix_github_version_tag: "v#{version.major}.#{version.minor}.#{version.patch}",
       phoenix_dep: phoenix_dep(phoenix_path),
       phoenix_path: phoenix_path,
       phoenix_webpack_path: phoenix_webpack_path(project, dev),


### PR DESCRIPTION
When generating a Phoenix 1.4.0 project, the link to the 1.4.0 changelong is:
https://github.com/phoenixframework/phoenix/blob/v1.4/CHANGELOG.md

This link is missing the patch. It should be:
https://github.com/phoenixframework/phoenix/blob/v1.4.0/CHANGELOG.md